### PR TITLE
feat: 融合上游更新并保留本地修复（含回归防护）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,17 +12,26 @@ ALLOWED_CHAT_USERNAMES=
 # 允许使用游戏命令的话题ID（逗号分隔；论坛群建议配置）
 # 示例：ALLOWED_TOPIC_THREAD_IDS=18833
 ALLOWED_TOPIC_THREAD_IDS=
+# 兼容旧配置：单个话题ID（0/空表示不限制）
+ALLOWED_TOPIC_THREAD_ID=0
 
 # 管理员TG用户ID（逗号分隔，必填）
 ADMIN_TG_IDS=
+# 超级管理员TG用户ID（高危命令专用）
+SUPER_ADMIN_TG_ID=
+# 多超级管理员（逗号分隔）。填写后可覆盖单一超管模式。
+SUPER_ADMIN_TG_IDS=
 
 # 管理员认证密钥（必填，用于/admin命令认证）
 ADMIN_SECRET_KEY=
 
 # 数据库（PostgreSQL推荐用于生产，SQLite用于开发）
-# PostgreSQL: postgresql+asyncpg://用户名:密码@localhost:5432/数据库名
+# PostgreSQL(容器内): postgresql+asyncpg://用户名:密码@postgres:5432/数据库名
 # SQLite: sqlite+aiosqlite:///my_company.db
-DATABASE_URL=sqlite+aiosqlite:///my_company.db
+DATABASE_URL=postgresql+asyncpg://mycompany:mycompany@postgres:5432/mycompany
+POSTGRES_DB=mycompany
+POSTGRES_USER=mycompany
+POSTGRES_PASSWORD=mycompany
 
 # Redis
 REDIS_URL=redis://localhost:6379/0
@@ -66,6 +75,12 @@ REPUTATION_PER_DIVIDEND=3
 # 每日结算时间（UTC）
 SETTLEMENT_HOUR=0
 SETTLEMENT_MINUTE=0
+
+# 自动备份（my_company 专用，文件写入项目根目录）
+BACKUP_ENABLED=true
+BACKUP_INTERVAL_MINUTES=60
+BACKUP_KEEP_FILES=72
+BACKUP_NOTIFY_SUPER_ADMIN=true
 
 # 随机事件
 EVENT_CHANCE=0.35

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+CMD ["python", "bot.py"]

--- a/README.md
+++ b/README.md
@@ -8,11 +8,30 @@
 - **Bot框架**: aiogram 3.x（异步Telegram框架）
 - **数据库**: PostgreSQL + asyncpg（通过SQLAlchemy 2.0 async ORM，支持高并发）
 - **缓存**: Redis（热数据/分布式锁/排行榜/冷却计时/管理员认证/道具Buff）
-- **定时任务**: APScheduler（每日结算）
+- **定时任务**: APScheduler（每日结算 + 自动备份）
 - **配置**: pydantic-settings（类型安全）
-- **包管理**: uv
+- **部署**: Docker Compose（推荐）/ 本地 Python 运行
 
-## 快速开始
+## 快速开始（Docker，推荐）
+
+```bash
+# 1. 克隆项目
+git clone https://github.com/keys-cherish/my_company.git
+cd my_company
+
+# 2. 配置环境变量
+cp .env.example .env
+# 编辑 .env 填入 BOT_TOKEN、管理员ID/超管ID、群组和话题限制等配置
+
+# 3. 启动（bot + postgres + redis）
+docker compose up -d --build
+
+# 4. 查看状态
+docker compose ps
+docker compose logs -f bot
+```
+
+## 快速开始（本地 Python）
 
 ```bash
 # 1. 克隆项目
@@ -67,10 +86,24 @@ uv run python bot.py
 
 所有游戏参数均可通过 `.env` 文件或管理员面板实时调整，详见 `.env.example`。
 
-若需要限制机器人只能在指定公司群使用，可配置以下任一项（或同时配置）：
-- `ALLOWED_CHAT_IDS=-100xxxxxxxxxx`
-- `ALLOWED_CHAT_USERNAMES=Anyincubation`
-- `ALLOWED_TOPIC_THREAD_IDS=18833`（仅允许指定话题）
+常用配置项：
+- `BOT_TOKEN`：机器人 token
+- `DATABASE_URL`：数据库连接（生产建议 PostgreSQL）
+- `REDIS_URL`：Redis 连接
+- `ADMIN_TG_IDS`：管理员 TG ID 列表（逗号分隔）
+- `SUPER_ADMIN_TG_ID` / `SUPER_ADMIN_TG_IDS`：超级管理员（支持单个或多个）
+- `ALLOWED_CHAT_IDS`：允许的群组 ID（逗号分隔）
+- `ALLOWED_CHAT_USERNAMES`：允许的群组用户名（可选，逗号分隔）
+- `ALLOWED_TOPIC_THREAD_IDS`：允许的话题 ID 列表（可选，逗号分隔）
+- `ALLOWED_TOPIC_THREAD_ID`：单话题兼容配置（旧版，保留可用）
+- `BACKUP_ENABLED`：是否启用自动备份
+- `BACKUP_INTERVAL_MINUTES`：自动备份间隔（分钟）
+- `BACKUP_KEEP_FILES`：本地保留的备份文件数量
+- `BACKUP_NOTIFY_SUPER_ADMIN`：备份结果是否私聊通知超管
+
+备份说明：
+- 备份文件写入项目根目录，文件名形如 `my_company_backup_YYYYMMDDTHHMMSSZ.json.gz`
+- 该备份是 `my_company` 项目独立文件，不使用 `dice_bot` 的 `backup.db`
 
 ## 项目结构
 

--- a/config.py
+++ b/config.py
@@ -18,9 +18,14 @@ class Settings(BaseSettings):
     # Comma-separated list of allowed topic(thread) IDs in forum supergroups.
     # Example: "18833,20001"
     allowed_topic_thread_ids: str = ""
+    # 兼容旧配置：单个论坛话题ID（message_thread_id）。0 表示不限制。
+    allowed_topic_thread_id: int = 0
 
     # Database
     database_url: str = "postgresql+asyncpg://mycompany:mycompany@localhost:5432/mycompany"
+    postgres_db: str = ""
+    postgres_user: str = ""
+    postgres_password: str = ""
 
     # Redis
     redis_url: str = "redis://localhost:6379/0"
@@ -56,6 +61,10 @@ class Settings(BaseSettings):
     # Settlement
     settlement_hour: int = 0  # midnight UTC
     settlement_minute: int = 0
+    backup_enabled: bool = True
+    backup_interval_minutes: int = 60
+    backup_keep_files: int = 72
+    backup_notify_super_admin: bool = True
 
     # Tax system
     tax_rate: float = 0.06
@@ -82,6 +91,8 @@ class Settings(BaseSettings):
     traffic_exchange_rate: float = 1.0  # 外部积分兑换流量汇率
 
     # 管理员
+    super_admin_tg_id: int = 0  # 兼容旧配置：单个超级管理员TG ID（高危命令）
+    super_admin_tg_ids: str = ""  # 新配置：逗号分隔的超级管理员TG ID列表
     admin_tg_ids: str = ""  # 逗号分隔的管理员TG ID列表
     admin_secret_key: str = ""  # 管理员认证密钥
 
@@ -90,6 +101,15 @@ class Settings(BaseSettings):
         if not self.admin_tg_ids.strip():
             return set()
         return {int(x.strip()) for x in self.admin_tg_ids.split(",") if x.strip()}
+
+    @property
+    def super_admin_tg_id_set(self) -> set[int]:
+        ids: set[int] = set()
+        if self.super_admin_tg_ids.strip():
+            ids.update({int(x.strip()) for x in self.super_admin_tg_ids.split(",") if x.strip()})
+        if self.super_admin_tg_id > 0:
+            ids.add(self.super_admin_tg_id)
+        return ids
 
     @property
     def allowed_chat_id_set(self) -> set[int]:
@@ -109,9 +129,12 @@ class Settings(BaseSettings):
 
     @property
     def allowed_topic_thread_id_set(self) -> set[int]:
-        if not self.allowed_topic_thread_ids.strip():
-            return set()
-        return {int(x.strip()) for x in self.allowed_topic_thread_ids.split(",") if x.strip()}
+        ids: set[int] = set()
+        if self.allowed_topic_thread_ids.strip():
+            ids.update({int(x.strip()) for x in self.allowed_topic_thread_ids.split(",") if x.strip()})
+        if self.allowed_topic_thread_id > 0:
+            ids.add(self.allowed_topic_thread_id)
+        return ids
 
 
 settings = Settings()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: my_company_postgres
+    restart: always
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-mycompany}
+      POSTGRES_USER: ${POSTGRES_USER:-mycompany}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-mycompany}
+    volumes:
+      - ./postgres_data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:alpine
+    container_name: my_company_redis
+    command: redis-server --appendonly yes
+    restart: always
+    volumes:
+      - ./redis_data:/data
+
+  bot:
+    build: .
+    container_name: my_company_bot
+    env_file:
+      - .env
+    environment:
+      REDIS_URL: redis://redis:6379/0
+    volumes:
+      - .:/app
+    depends_on:
+      - postgres
+      - redis
+    restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "5m"
+        max-file: "3"

--- a/handlers/ad.py
+++ b/handlers/ad.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from aiogram import F, Router, types
 
 from db.engine import async_session
-from keyboards.menus import main_menu_kb
+from keyboards.menus import main_menu_kb, tag_kb
 from services.ad_service import get_active_ad_info, get_ad_tiers, buy_ad, cancel_ad
 from services.company_service import add_funds, get_company_by_id
 from services.user_service import get_user_by_tg_id
@@ -14,7 +14,7 @@ from handlers.company import _refresh_company_view
 router = Router()
 
 
-def _ad_menu_kb(company_id: int):
+def _ad_menu_kb(company_id: int, tg_id: int | None = None):
     from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
     tiers = get_ad_tiers()
     buttons = [
@@ -25,7 +25,7 @@ def _ad_menu_kb(company_id: int):
         for t in tiers
     ]
     buttons.append([InlineKeyboardButton(text="🔙 返回", callback_data=f"company:view:{company_id}")])
-    return InlineKeyboardMarkup(inline_keyboard=buttons)
+    return tag_kb(InlineKeyboardMarkup(inline_keyboard=buttons), tg_id)
 
 
 @router.callback_query(F.data.startswith("ad:menu:"))
@@ -44,6 +44,7 @@ async def cb_ad_menu(callback: types.CallbackQuery):
             return
 
     ad_info = await get_active_ad_info(company_id)
+    tg_id = callback.from_user.id
     if ad_info:
         text = (
             f"📢 广告投放\n"
@@ -53,12 +54,12 @@ async def cb_ad_menu(callback: types.CallbackQuery):
             "当前已有活动广告，请等待结束后购买新广告。"
         )
         from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
-        kb = InlineKeyboardMarkup(inline_keyboard=[
+        kb = tag_kb(InlineKeyboardMarkup(inline_keyboard=[
             [InlineKeyboardButton(text="🔙 返回", callback_data=f"company:view:{company_id}")]
-        ])
+        ]), tg_id)
         await callback.message.edit_text(text, reply_markup=kb)
     else:
-        await callback.message.edit_text("📢 选择广告方案:", reply_markup=_ad_menu_kb(company_id))
+        await callback.message.edit_text("📢 选择广告方案:", reply_markup=_ad_menu_kb(company_id, tg_id=tg_id))
     await callback.answer()
 
 

--- a/handlers/common.py
+++ b/handlers/common.py
@@ -14,7 +14,6 @@ from config import settings
 
 router = Router()
 logger = logging.getLogger(__name__)
-SUPER_ADMIN_TG_ID = 5222591634
 CHANNEL_ONLY_HINT = "❌ 本 bot 仅在指定话题频道内提供服务。"
 
 # ---- 管理员认证 ----
@@ -37,7 +36,7 @@ async def is_admin_authenticated(tg_id: int) -> bool:
 
 def is_super_admin(tg_id: int) -> bool:
     """Strict super-admin check for high-risk commands."""
-    return tg_id == SUPER_ADMIN_TG_ID
+    return tg_id in settings.super_admin_tg_id_set
 
 
 async def authenticate_admin(tg_id: int, secret_key: str) -> tuple[bool, str]:
@@ -186,4 +185,4 @@ group_scope_middleware = GroupScopeMiddleware()
 
 async def reject_private(message: types.Message):
     """非管理员私聊时的拒绝提示。"""
-    await message.answer(CHANNEL_ONLY_HINT)
+    await message.answer("此命令仅限在群组指定频道中使用。\n私聊仅支持 /create_company 和 /company 查看信息。")

--- a/handlers/dividend.py
+++ b/handlers/dividend.py
@@ -26,7 +26,7 @@ async def cb_dividend_menu(callback: types.CallbackQuery):
         companies = await get_companies_by_owner(session, user.id)
 
         if not companies:
-            await callback.message.edit_text("你还没有公司。", reply_markup=main_menu_kb())
+            await callback.message.edit_text("你还没有公司。", reply_markup=main_menu_kb(tg_id=callback.from_user.id))
             await callback.answer()
             return
 
@@ -46,5 +46,5 @@ async def cb_dividend_menu(callback: types.CallbackQuery):
             else:
                 lines.append(f"「{company.name}」暂无结算记录")
 
-    await callback.message.edit_text("\n".join(lines), reply_markup=main_menu_kb())
+    await callback.message.edit_text("\n".join(lines), reply_markup=main_menu_kb(tg_id=callback.from_user.id))
     await callback.answer()

--- a/handlers/product.py
+++ b/handlers/product.py
@@ -11,7 +11,7 @@ from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
 from db.engine import async_session
 from handlers.common import is_super_admin
-from keyboards.menus import product_detail_kb, product_template_kb
+from keyboards.menus import product_detail_kb, product_template_kb, tag_kb
 from services.company_service import get_company_by_id, get_companies_by_owner, update_daily_revenue, add_funds
 from services.product_service import (
     create_product,
@@ -191,6 +191,7 @@ async def cmd_new_product(message: types.Message):
 
 async def _refresh_product_list(callback: types.CallbackQuery, company_id: int):
     """操作后刷新产品列表消息。"""
+    tg_id = callback.from_user.id
     try:
         async with async_session() as session:
             company = await get_company_by_id(session, company_id)
@@ -225,7 +226,7 @@ async def _refresh_product_list(callback: types.CallbackQuery, company_id: int):
         ]
         all_buttons = product_buttons + template_buttons
         all_buttons.append([InlineKeyboardButton(text="🔙 返回", callback_data=f"company:view:{company_id}")])
-        kb = InlineKeyboardMarkup(inline_keyboard=all_buttons)
+        kb = tag_kb(InlineKeyboardMarkup(inline_keyboard=all_buttons), tg_id)
 
         await callback.message.edit_text(text, reply_markup=kb)
     except Exception:
@@ -259,7 +260,7 @@ async def cb_product_menu(callback: types.CallbackQuery):
     buttons.append([InlineKeyboardButton(text="🔙 返回", callback_data="menu:company")])
     await callback.message.edit_text(
         "📦 选择公司查看产品:",
-        reply_markup=InlineKeyboardMarkup(inline_keyboard=buttons),
+        reply_markup=tag_kb(InlineKeyboardMarkup(inline_keyboard=buttons), callback.from_user.id),
     )
     await callback.answer()
 
@@ -315,7 +316,7 @@ async def cb_product_list(callback: types.CallbackQuery, company_id: int | None 
     text = "\n".join(lines)
     all_buttons = product_buttons + template_buttons
     all_buttons.append([InlineKeyboardButton(text="🔙 返回", callback_data=f"company:view:{company_id}")])
-    kb = InlineKeyboardMarkup(inline_keyboard=all_buttons)
+    kb = tag_kb(InlineKeyboardMarkup(inline_keyboard=all_buttons), callback.from_user.id)
 
     try:
         await callback.message.edit_text(text, reply_markup=kb)

--- a/handlers/realestate.py
+++ b/handlers/realestate.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from aiogram import F, Router, types
 
 from db.engine import async_session
-from keyboards.menus import building_list_kb
+from keyboards.menus import building_list_kb, tag_kb
 from services.company_service import get_company_by_id
 from services.realestate_service import get_building_list, get_company_estates, purchase_building
 from services.user_service import get_user_by_tg_id
@@ -16,6 +16,7 @@ router = Router()
 
 async def _refresh_estate_list(callback: types.CallbackQuery, company_id: int):
     """操作后刷新地产列表消息。"""
+    tg_id = callback.from_user.id
     try:
         async with async_session() as session:
             company = await get_company_by_id(session, company_id)
@@ -36,7 +37,7 @@ async def _refresh_estate_list(callback: types.CallbackQuery, company_id: int):
         lines.append("\n🏪 可购买地产:")
         buildings = get_building_list()
         text = "\n".join(lines)
-        await callback.message.edit_text(text, reply_markup=building_list_kb(buildings, company_id))
+        await callback.message.edit_text(text, reply_markup=building_list_kb(buildings, company_id, tg_id=tg_id))
     except Exception:
         pass  # 消息未变化时edit会抛异常，忽略
 
@@ -69,7 +70,7 @@ async def cb_realestate_menu(callback: types.CallbackQuery):
     buttons.append([InlineKeyboardButton(text="🔙 返回", callback_data="menu:company")])
     await callback.message.edit_text(
         "🏗 选择公司查看地产:",
-        reply_markup=InlineKeyboardMarkup(inline_keyboard=buttons),
+        reply_markup=tag_kb(InlineKeyboardMarkup(inline_keyboard=buttons), callback.from_user.id),
     )
     await callback.answer()
 
@@ -104,7 +105,7 @@ async def cb_estate_list(callback: types.CallbackQuery, company_id: int | None =
     lines.append("\n🏪 可购买地产:")
     buildings = get_building_list()
     text = "\n".join(lines)
-    await callback.message.edit_text(text, reply_markup=building_list_kb(buildings, company_id))
+    await callback.message.edit_text(text, reply_markup=building_list_kb(buildings, company_id, tg_id=callback.from_user.id))
     await callback.answer()
 
 

--- a/handlers/research.py
+++ b/handlers/research.py
@@ -8,7 +8,7 @@ from aiogram import F, Router, types
 from sqlalchemy import func as sqlfunc, select
 
 from db.engine import async_session
-from keyboards.menus import tech_list_kb
+from keyboards.menus import tech_list_kb, tag_kb
 from services.company_service import get_company_by_id
 from services.research_service import (
     get_available_techs,
@@ -52,7 +52,7 @@ async def cb_research_menu(callback: types.CallbackQuery):
     buttons.append([InlineKeyboardButton(text="🔙 返回", callback_data="menu:company")])
     await callback.message.edit_text(
         "🔬 选择公司查看科研:",
-        reply_markup=InlineKeyboardMarkup(inline_keyboard=buttons),
+        reply_markup=tag_kb(InlineKeyboardMarkup(inline_keyboard=buttons), callback.from_user.id),
     )
     await callback.answer()
 
@@ -122,7 +122,7 @@ async def cb_research_list(callback: types.CallbackQuery, company_id: int | None
         lines.append("暂无可研究科技")
 
     text = "\n".join(lines)
-    await callback.message.edit_text(text, reply_markup=tech_list_kb(available, company_id))
+    await callback.message.edit_text(text, reply_markup=tech_list_kb(available, company_id, tg_id=callback.from_user.id))
     await callback.answer()
 
 @router.callback_query(F.data.startswith("research:start:"))

--- a/handlers/roadshow.py
+++ b/handlers/roadshow.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from aiogram import F, Router, types
 
 from db.engine import async_session
-from keyboards.menus import main_menu_kb
+from keyboards.menus import main_menu_kb, tag_kb
 from services.company_service import get_companies_by_owner, get_company_by_id
 from services.roadshow_service import do_roadshow
 from services.user_service import get_user_by_tg_id
@@ -40,7 +40,7 @@ async def cb_roadshow_menu(callback: types.CallbackQuery):
     buttons.append([InlineKeyboardButton(text="🔙 返回", callback_data="menu:company")])
     await callback.message.edit_text(
         "🎤 选择公司发起路演:",
-        reply_markup=InlineKeyboardMarkup(inline_keyboard=buttons),
+        reply_markup=tag_kb(InlineKeyboardMarkup(inline_keyboard=buttons), callback.from_user.id),
     )
     await callback.answer()
 
@@ -64,7 +64,11 @@ async def cb_do_roadshow(callback: types.CallbackQuery, company_id: int | None =
             ok, msg = await do_roadshow(session, company_id, user.id)
 
     if ok:
-        await callback.message.edit_text(f"🎤 路演结果\n\n{msg}", reply_markup=main_menu_kb())
+        from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+        result_kb = tag_kb(InlineKeyboardMarkup(inline_keyboard=[
+            [InlineKeyboardButton(text="🔙 返回公司", callback_data=f"company:view:{company_id}")],
+        ]), callback.from_user.id)
+        await callback.message.edit_text(f"🎤 路演结果\n\n{msg}", reply_markup=result_kb)
         await callback.answer()
     else:
         await callback.answer(msg, show_alert=True)

--- a/handlers/shareholder.py
+++ b/handlers/shareholder.py
@@ -27,6 +27,7 @@ class InvestState(StatesGroup):
 
 async def _refresh_shareholder_list(callback: types.CallbackQuery, company_id: int):
     """操作后刷新股东列表消息。"""
+    tg_id = callback.from_user.id
     try:
         async with async_session() as session:
             shareholders = await get_shareholders(session, company_id)
@@ -40,7 +41,7 @@ async def _refresh_shareholder_list(callback: types.CallbackQuery, company_id: i
         from keyboards.menus import company_detail_kb
         await callback.message.edit_text(
             "\n".join(lines),
-            reply_markup=company_detail_kb(company_id, False),
+            reply_markup=company_detail_kb(company_id, False, tg_id=tg_id),
         )
     except Exception:
         pass  # 消息未变化时edit会抛异常，忽略
@@ -62,7 +63,7 @@ async def cb_shareholders(callback: types.CallbackQuery):
     from keyboards.menus import company_detail_kb
     await callback.message.edit_text(
         "\n".join(lines),
-        reply_markup=company_detail_kb(company_id, False),
+        reply_markup=company_detail_kb(company_id, False, tg_id=callback.from_user.id),
     )
     await callback.answer()
 
@@ -70,7 +71,7 @@ async def cb_shareholders(callback: types.CallbackQuery):
 @router.callback_query(F.data.startswith("shareholder:invest:"))
 async def cb_invest_menu(callback: types.CallbackQuery):
     company_id = int(callback.data.split(":")[2])
-    await callback.message.edit_text("选择投资金额:", reply_markup=invest_kb(company_id))
+    await callback.message.edit_text("选择投资金额:", reply_markup=invest_kb(company_id, tg_id=callback.from_user.id))
     await callback.answer()
 
 

--- a/keyboards/menus.py
+++ b/keyboards/menus.py
@@ -5,11 +5,30 @@ from __future__ import annotations
 from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
 
+def tag_kb(kb: InlineKeyboardMarkup, tg_id: int | None) -> InlineKeyboardMarkup:
+    """Tag callbacks with panel owner tg_id for middleware auth."""
+    if tg_id is None:
+        return kb
+    new_rows = []
+    for row in kb.inline_keyboard:
+        new_row = []
+        for btn in row:
+            if btn.callback_data:
+                new_row.append(InlineKeyboardButton(
+                    text=btn.text,
+                    callback_data=f"{btn.callback_data}|{tg_id}",
+                ))
+            else:
+                new_row.append(btn)
+        new_rows.append(new_row)
+    return InlineKeyboardMarkup(inline_keyboard=new_rows)
+
+
 # ---- Main menu (simplified: redirects to company view) ----
 
-def main_menu_kb() -> InlineKeyboardMarkup:
+def main_menu_kb(tg_id: int | None = None) -> InlineKeyboardMarkup:
     """Simplified menu — goes to company view (the main hub now)."""
-    return InlineKeyboardMarkup(inline_keyboard=[
+    kb = InlineKeyboardMarkup(inline_keyboard=[
         [
             InlineKeyboardButton(text="🏢 我的公司", callback_data="menu:company"),
             InlineKeyboardButton(text="📊 个人面板", callback_data="menu:profile"),
@@ -19,20 +38,23 @@ def main_menu_kb() -> InlineKeyboardMarkup:
             InlineKeyboardButton(text="🎯 周任务", callback_data="menu:quest"),
         ],
     ])
+    return tag_kb(kb, tg_id)
 
 
 # ---- Company ----
 
-def company_list_kb(companies: list[tuple[int, str]]) -> InlineKeyboardMarkup:
+def company_list_kb(companies: list[tuple[int, str]], tg_id: int | None = None) -> InlineKeyboardMarkup:
     buttons = [
         [InlineKeyboardButton(text=name, callback_data=f"company:view:{cid}")]
         for cid, name in companies
     ]
     buttons.append([InlineKeyboardButton(text="➕ 创建公司", callback_data="company:create")])
-    return InlineKeyboardMarkup(inline_keyboard=buttons)
+    buttons.append([InlineKeyboardButton(text="🔙 返回", callback_data="menu:main")])
+    kb = InlineKeyboardMarkup(inline_keyboard=buttons)
+    return tag_kb(kb, tg_id)
 
 
-def company_detail_kb(company_id: int, is_owner: bool) -> InlineKeyboardMarkup:
+def company_detail_kb(company_id: int, is_owner: bool, tg_id: int | None = None) -> InlineKeyboardMarkup:
     buttons = [
         [
             InlineKeyboardButton(text="👥 股东", callback_data=f"shareholder:list:{company_id}"),
@@ -49,7 +71,7 @@ def company_detail_kb(company_id: int, is_owner: bool) -> InlineKeyboardMarkup:
         ])
         buttons.append([
             InlineKeyboardButton(text="🎤 路演", callback_data=f"roadshow:do:{company_id}"),
-            InlineKeyboardButton(text="🤝 发起合作", callback_data=f"cooperation:init:{company_id}"),
+            InlineKeyboardButton(text="🤝 合作状态", callback_data=f"cooperation:init:{company_id}"),
         ])
         buttons.append([
             InlineKeyboardButton(text="📢 广告", callback_data=f"ad:menu:{company_id}"),
@@ -74,12 +96,13 @@ def company_detail_kb(company_id: int, is_owner: bool) -> InlineKeyboardMarkup:
     buttons.append([
         InlineKeyboardButton(text="📋 公司列表", callback_data="menu:company_list"),
     ])
-    return InlineKeyboardMarkup(inline_keyboard=buttons)
+    kb = InlineKeyboardMarkup(inline_keyboard=buttons)
+    return tag_kb(kb, tg_id)
 
 
 # ---- Shareholders ----
 
-def invest_kb(company_id: int) -> InlineKeyboardMarkup:
+def invest_kb(company_id: int, tg_id: int | None = None) -> InlineKeyboardMarkup:
     amounts = [500, 1000, 2000, 5000]
     buttons = [
         [InlineKeyboardButton(text=f"投资 {a:,} 金币", callback_data=f"shareholder:doinvest:{company_id}:{a}")]
@@ -87,12 +110,13 @@ def invest_kb(company_id: int) -> InlineKeyboardMarkup:
     ]
     buttons.append([InlineKeyboardButton(text="✍️ 自定义金额（文本）", callback_data=f"shareholder:input:{company_id}")])
     buttons.append([InlineKeyboardButton(text="🔙 返回", callback_data=f"company:view:{company_id}")])
-    return InlineKeyboardMarkup(inline_keyboard=buttons)
+    kb = InlineKeyboardMarkup(inline_keyboard=buttons)
+    return tag_kb(kb, tg_id)
 
 
 # ---- Research ----
 
-def tech_list_kb(techs: list[dict], company_id: int) -> InlineKeyboardMarkup:
+def tech_list_kb(techs: list[dict], company_id: int, tg_id: int | None = None) -> InlineKeyboardMarkup:
     from utils.formatters import fmt_duration
     buttons = [
         [InlineKeyboardButton(
@@ -102,12 +126,13 @@ def tech_list_kb(techs: list[dict], company_id: int) -> InlineKeyboardMarkup:
         for t in techs
     ]
     buttons.append([InlineKeyboardButton(text="🔙 返回", callback_data=f"company:view:{company_id}")])
-    return InlineKeyboardMarkup(inline_keyboard=buttons)
+    kb = InlineKeyboardMarkup(inline_keyboard=buttons)
+    return tag_kb(kb, tg_id)
 
 
 # ---- Products ----
 
-def product_template_kb(templates: list[dict], company_id: int) -> InlineKeyboardMarkup:
+def product_template_kb(templates: list[dict], company_id: int, tg_id: int | None = None) -> InlineKeyboardMarkup:
     buttons = [
         [InlineKeyboardButton(
             text=f"{t['name']} (💰{t['base_daily_income']:,}/日)",
@@ -116,22 +141,24 @@ def product_template_kb(templates: list[dict], company_id: int) -> InlineKeyboar
         for t in templates
     ]
     buttons.append([InlineKeyboardButton(text="🔙 返回", callback_data=f"company:view:{company_id}")])
-    return InlineKeyboardMarkup(inline_keyboard=buttons)
+    kb = InlineKeyboardMarkup(inline_keyboard=buttons)
+    return tag_kb(kb, tg_id)
 
 
-def product_detail_kb(product_id: int, company_id: int) -> InlineKeyboardMarkup:
-    return InlineKeyboardMarkup(inline_keyboard=[
+def product_detail_kb(product_id: int, company_id: int, tg_id: int | None = None) -> InlineKeyboardMarkup:
+    kb = InlineKeyboardMarkup(inline_keyboard=[
         [
             InlineKeyboardButton(text="⬆️ 升级x1", callback_data=f"product:upgrade:{product_id}:1"),
             InlineKeyboardButton(text="⬆️⬆️ 升级x5", callback_data=f"product:upgrade:{product_id}:5"),
         ],
         [InlineKeyboardButton(text="🔙 返回", callback_data=f"product:list:{company_id}")],
     ])
+    return tag_kb(kb, tg_id)
 
 
 # ---- Real Estate ----
 
-def building_list_kb(buildings: list[dict], company_id: int) -> InlineKeyboardMarkup:
+def building_list_kb(buildings: list[dict], company_id: int, tg_id: int | None = None) -> InlineKeyboardMarkup:
     buttons = [
         [InlineKeyboardButton(
             text=f"{b['name']} (💰{b['purchase_price']:,} → {b['daily_dividend']:,}/日)",
@@ -140,12 +167,13 @@ def building_list_kb(buildings: list[dict], company_id: int) -> InlineKeyboardMa
         for b in buildings
     ]
     buttons.append([InlineKeyboardButton(text="🔙 返回", callback_data=f"company:view:{company_id}")])
-    return InlineKeyboardMarkup(inline_keyboard=buttons)
+    kb = InlineKeyboardMarkup(inline_keyboard=buttons)
+    return tag_kb(kb, tg_id)
 
 
 # ---- Exchange ----
 
-def exchange_kb(rate_per_mb: int | None = None) -> InlineKeyboardMarkup:
+def exchange_kb(rate_per_mb: int | None = None, tg_id: int | None = None) -> InlineKeyboardMarkup:
     spend_amounts = [1_000, 3_000, 8_000, 15_000]
     safe_rate = max(1, rate_per_mb or 120)
     buttons = [
@@ -155,8 +183,9 @@ def exchange_kb(rate_per_mb: int | None = None) -> InlineKeyboardMarkup:
         )]
         for amount in spend_amounts
     ]
-    buttons.append([InlineKeyboardButton(text="🔙 返回", callback_data="menu:company")])
-    return InlineKeyboardMarkup(inline_keyboard=buttons)
+    buttons.append([InlineKeyboardButton(text="🔙 返回", callback_data="menu:main")])
+    kb = InlineKeyboardMarkup(inline_keyboard=buttons)
+    return tag_kb(kb, tg_id)
 
 
 # ---- Pagination helper ----
@@ -166,6 +195,7 @@ def paginated_kb(
     page: int,
     total_pages: int,
     prefix: str,
+    tg_id: int | None = None,
 ) -> InlineKeyboardMarkup:
     rows = [[btn] for btn in items]
     nav = []
@@ -175,16 +205,18 @@ def paginated_kb(
         nav.append(InlineKeyboardButton(text="➡️ 下一页", callback_data=f"{prefix}:page:{page + 1}"))
     if nav:
         rows.append(nav)
-    rows.append([InlineKeyboardButton(text="🔙 返回", callback_data="menu:company")])
-    return InlineKeyboardMarkup(inline_keyboard=rows)
+    rows.append([InlineKeyboardButton(text="🔙 返回", callback_data="menu:main")])
+    kb = InlineKeyboardMarkup(inline_keyboard=rows)
+    return tag_kb(kb, tg_id)
 
 
 # ---- Confirm ----
 
-def confirm_kb(action: str) -> InlineKeyboardMarkup:
-    return InlineKeyboardMarkup(inline_keyboard=[
+def confirm_kb(action: str, tg_id: int | None = None) -> InlineKeyboardMarkup:
+    kb = InlineKeyboardMarkup(inline_keyboard=[
         [
             InlineKeyboardButton(text="✅ 确认", callback_data=f"confirm:{action}"),
             InlineKeyboardButton(text="❌ 取消", callback_data="cancel"),
         ],
     ])
+    return tag_kb(kb, tg_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+aiogram>=3.4,<4
+SQLAlchemy[asyncio]>=2.0
+aiosqlite>=0.19
+alembic>=1.13
+redis[hiredis]>=5.0
+apscheduler>=3.10,<4
+pydantic-settings>=2.1
+httpx>=0.27
+aiohttp-socks>=0.11.0
+asyncpg>=0.31.0

--- a/scheduler/daily_settlement.py
+++ b/scheduler/daily_settlement.py
@@ -2,23 +2,121 @@
 
 from __future__ import annotations
 
+import datetime as dt
+import gzip
+import json
 import logging
+from decimal import Decimal
+from pathlib import Path
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from sqlalchemy import text
 
 from config import settings
-from db.engine import async_session
+from db.engine import async_session, engine
 from services.settlement_service import format_daily_report, settle_all
 
 logger = logging.getLogger(__name__)
 
 _scheduler: AsyncIOScheduler | None = None
 _bot_ref = None  # will be set at startup
+_BACKUP_DIR = Path(".")
 
 
 def set_bot(bot):
     global _bot_ref
     _bot_ref = bot
+
+
+def _json_safe(value):
+    if isinstance(value, (dt.datetime, dt.date, dt.time)):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return int(value) if value == value.to_integral_value() else float(value)
+    return value
+
+
+def _write_backup_file(path: Path, payload: dict):
+    with gzip.open(path, "wt", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False)
+
+
+def _rotate_old_backups(keep_files: int):
+    if keep_files <= 0:
+        return
+    files = sorted(_BACKUP_DIR.glob("my_company_backup_*.json.gz"))
+    overflow = len(files) - keep_files
+    if overflow <= 0:
+        return
+    for old_file in files[:overflow]:
+        old_file.unlink(missing_ok=True)
+
+
+async def _create_db_backup() -> tuple[Path, dict[str, int]]:
+    from db.models import Base
+
+    _BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    now_utc = dt.datetime.now(dt.UTC)
+    file_path = _BACKUP_DIR / f"my_company_backup_{now_utc.strftime('%Y%m%dT%H%M%SZ')}.json.gz"
+
+    table_data: dict[str, list[dict]] = {}
+    table_counts: dict[str, int] = {}
+
+    async with engine.connect() as conn:
+        for table in Base.metadata.sorted_tables:
+            result = await conn.execute(text(f'SELECT * FROM "{table.name}"'))
+            rows = []
+            for row in result.mappings().all():
+                rows.append({k: _json_safe(v) for k, v in row.items()})
+            table_data[table.name] = rows
+            table_counts[table.name] = len(rows)
+
+    payload = {
+        "project": "my_company",
+        "created_at_utc": now_utc.isoformat(),
+        "tables": table_data,
+    }
+    _write_backup_file(file_path, payload)
+    _rotate_old_backups(settings.backup_keep_files)
+    return file_path, table_counts
+
+
+async def _notify_backup_status(text_msg: str):
+    if not _bot_ref or not settings.backup_notify_super_admin:
+        return
+    admin_ids = settings.super_admin_tg_id_set
+    if not admin_ids:
+        return
+    for admin_tg_id in admin_ids:
+        try:
+            await _bot_ref.send_message(admin_tg_id, text_msg)
+        except Exception:
+            logger.exception("Failed to notify super admin %s for backup", admin_tg_id)
+
+
+async def _backup_job():
+    if not settings.backup_enabled:
+        return
+
+    try:
+        file_path, table_counts = await _create_db_backup()
+        total_rows = sum(table_counts.values())
+        summary = ", ".join(f"{name}:{count}" for name, count in sorted(table_counts.items()))
+        logger.info("DB backup completed: %s rows=%d", file_path, total_rows)
+        await _notify_backup_status(
+            "🛡 my_company 自动备份完成\n"
+            f"⏰ UTC时间: {dt.datetime.now(dt.UTC).strftime('%Y-%m-%d %H:%M:%S')}\n"
+            f"📦 文件: {file_path}\n"
+            f"🧾 总行数: {total_rows}\n"
+            f"📚 分表: {summary}",
+        )
+    except Exception as exc:
+        logger.exception("DB backup failed")
+        await _notify_backup_status(
+            "❌ my_company 自动备份失败\n"
+            f"⏰ UTC时间: {dt.datetime.now(dt.UTC).strftime('%Y-%m-%d %H:%M:%S')}\n"
+            f"原因: {exc}",
+        )
 
 
 async def _daily_job():
@@ -61,8 +159,21 @@ def start_scheduler():
         minute=settings.settlement_minute,
         id="daily_settlement",
     )
+    if settings.backup_enabled and settings.backup_interval_minutes > 0:
+        _scheduler.add_job(
+            _backup_job,
+            "interval",
+            minutes=settings.backup_interval_minutes,
+            id="db_backup",
+        )
     _scheduler.start()
     logger.info("Scheduler started: daily settlement at %02d:%02d UTC", settings.settlement_hour, settings.settlement_minute)
+    if settings.backup_enabled and settings.backup_interval_minutes > 0:
+        logger.info(
+            "Scheduler started: DB backup every %d minutes (keep %d files)",
+            settings.backup_interval_minutes,
+            settings.backup_keep_files,
+        )
 
 
 def stop_scheduler():

--- a/utils/panel_auth.py
+++ b/utils/panel_auth.py
@@ -1,0 +1,41 @@
+"""Panel ownership middleware — ensures only the invoker can interact with a panel."""
+
+from __future__ import annotations
+
+from aiogram import BaseMiddleware
+from aiogram.types import CallbackQuery
+
+
+class PanelOwnerMiddleware(BaseMiddleware):
+    """Outer middleware for callback queries.
+
+    Convention: callback_data may end with ``|<tg_id>`` to mark panel ownership.
+    If the suffix is present and the caller's tg_id does not match, the callback
+    is rejected with an alert.  The suffix is stripped before passing to handlers
+    so that existing parsers continue to work unchanged.
+    """
+
+    async def __call__(self, handler, event: CallbackQuery, data: dict):
+        raw = event.data
+        if raw and "|" in raw:
+            parts = raw.rsplit("|", 1)
+            try:
+                owner_id = int(parts[1])
+            except ValueError:
+                # Not a valid tg_id suffix — pass through unchanged
+                return await handler(event, data)
+
+            if event.from_user.id != owner_id:
+                await event.answer("\u26a0\ufe0f 这不是你的面板", show_alert=True)
+                return
+
+            # Strip ownership suffix for downstream filters/handlers.
+            # Do not mutate event in place: Telegram objects may be immutable.
+            clean_data = parts[0]
+            try:
+                event = event.model_copy(update={"data": clean_data})
+            except Exception:
+                # Fallback for mutable model variants.
+                event.data = clean_data
+
+        return await handler(event, data)

--- a/utils/topic_gate.py
+++ b/utils/topic_gate.py
@@ -1,0 +1,75 @@
+"""Global chat/topic restriction middleware."""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable
+
+from aiogram import BaseMiddleware
+from aiogram.types import CallbackQuery, Message, TelegramObject
+
+from config import settings
+
+
+def _is_allowed_group_topic(chat_id: int, chat_username: str | None, thread_id: int | None) -> bool:
+    allowed_chat_ids = settings.allowed_chat_id_set
+    allowed_chat_usernames = settings.allowed_chat_username_set
+    allowed_thread_ids = settings.allowed_topic_thread_id_set
+
+    if allowed_chat_ids and chat_id in allowed_chat_ids:
+        chat_allowed = True
+    else:
+        username = (chat_username or "").lstrip("@").lower()
+        chat_allowed = bool(allowed_chat_usernames and username in allowed_chat_usernames)
+
+    if (allowed_chat_ids or allowed_chat_usernames) and not chat_allowed:
+        return False
+    if allowed_thread_ids and thread_id not in allowed_thread_ids:
+        return False
+    return True
+
+
+def _restriction_enabled() -> bool:
+    return (
+        bool(settings.allowed_chat_id_set)
+        or bool(settings.allowed_chat_username_set)
+        or bool(settings.allowed_topic_thread_id_set)
+    )
+
+
+class TopicGateMiddleware(BaseMiddleware):
+    """Allow bot interactions only in configured group/topic when enabled."""
+
+    async def __call__(
+        self,
+        handler: Callable[[TelegramObject, dict[str, Any]], Awaitable[Any]],
+        event: TelegramObject,
+        data: dict[str, Any],
+    ) -> Any:
+        if not _restriction_enabled():
+            return await handler(event, data)
+
+        if isinstance(event, Message):
+            chat = event.chat
+            thread_id = event.message_thread_id
+            if chat.type not in ("group", "supergroup") or not _is_allowed_group_topic(
+                chat.id,
+                chat.username,
+                thread_id,
+            ):
+                await event.answer("❌ 仅允许在指定话题频道使用本机器人。")
+                return None
+            return await handler(event, data)
+
+        if isinstance(event, CallbackQuery) and event.message:
+            chat = event.message.chat
+            thread_id = event.message.message_thread_id
+            if chat.type not in ("group", "supergroup") or not _is_allowed_group_topic(
+                chat.id,
+                chat.username,
+                thread_id,
+            ):
+                await event.answer("❌ 仅允许在指定话题频道使用本机器人。", show_alert=True)
+                return None
+            return await handler(event, data)
+
+        return await handler(event, data)


### PR DESCRIPTION
## 变更目标
本 PR 基于上游最新 `origin/main` 进行整合，不做机械覆盖，采用"择优融合"：
- 吸收原作者近期更新
- 保留并加固 fork 中已验证的修复
- 避免历史问题回归

## 保留并加固的关键修复
- 面板 owner 鉴权链路修复，避免 callback_data 处理导致权限绕过/异常
- 公司创建后的菜单返回修复（`main_menu_kb`）
- 公司列表按钮 owner tag 补齐，防止跨用户误操作
- 自动备份能力保留（定时备份、文件轮转、超管通知）

## 吸收的上游改进
- 作用域限制能力增强（群组 ID / 群用户名 / topic 多配置）
- 相关配置项与文档同步更新

## 兼容性与回归防护
- 兼容旧配置：`ALLOWED_TOPIC_THREAD_ID`
- 新配置支持：`ALLOWED_CHAT_USERNAMES`、`ALLOWED_TOPIC_THREAD_IDS`
- 保持 Docker + PostgreSQL + Redis 运行方式

## 本地验证
- `docker compose up -d --build` 可正常拉起
- `bot/postgres/redis` 容器均正常运行
- 启动日志确认轮询正常、每日结算与备份任务已注册

> 说明：原 pull/6 因历史 force-push 已无法 reopen（GitHub 返回 422），本 PR 为其替代续更。