### PR TITLE
fix: 补充遗漏的 calc_employee_income 和 sync_research_progress_if_due

### DIFF
--- a/services/company_service.py
+++ b/services/company_service.py
@@ -213,6 +213,24 @@ def get_company_employee_limit(level: int, company_type: str | None = None) -> i
     return max(settings.base_employee_limit, min(total, settings.max_employee_limit))
 
 
+def calc_employee_income(employee_count: int, revenue: int) -> tuple[int, int]:
+    """Calculate employee workforce income contribution.
+
+    Returns (base_output, efficiency_bonus).
+    """
+    if employee_count <= 0:
+        return (0, 0)
+
+    # Base output: each employee produces 1.5x their salary
+    base_output = int(employee_count * settings.employee_salary_base * 1.5)
+
+    # Efficiency bonus: proportional to revenue, diminishing past soft cap
+    effective = min(employee_count, settings.employee_effective_cap_for_progress)
+    efficiency_bonus = int(revenue * effective * 0.002)
+
+    return (base_output, efficiency_bonus)
+
+
 def get_effective_employee_count_for_progress(employee_count: int) -> int:
     """Soft-cap effective workforce used by progression gates."""
     if employee_count <= 0:

--- a/services/research_service.py
+++ b/services/research_service.py
@@ -282,6 +282,11 @@ async def start_research(
     )
 
 
+async def sync_research_progress_if_due(session: AsyncSession, company_id: int) -> list[str]:
+    """Alias for check_and_complete_research – used by company view to sync state."""
+    return await check_and_complete_research(session, company_id)
+
+
 async def check_and_complete_research(session: AsyncSession, company_id: int) -> list[str]:
     """Check all in-progress research; complete those past duration. Returns list of completed tech names."""
     tree = _load_tech_tree()


### PR DESCRIPTION
## Summary
- 补充 `calc_employee_income()` 到 `services/company_service.py`（员工基础产出 + 效率加成计算）
- 补充 `sync_research_progress_if_due()` 到 `services/research_service.py`（公司详情页刷新研发进度）

上游 59e6dbf 拆分 `company.py` 时引用了这两个函数但未定义，导致 bot 启动时 `ImportError`。

## Test plan
- [x] `docker compose restart bot` 启动成功，无 ImportError
- [ ] 查看公司详情页正常显示员工产出数据
- [ ] 日结算流程正常执行

🤖 Generated with [Claude Code](https://claude.com/claude-code)